### PR TITLE
Fix typo in tooltip

### DIFF
--- a/coin_client/src/components/CryptoTable/CryptoTable.jsx
+++ b/coin_client/src/components/CryptoTable/CryptoTable.jsx
@@ -101,7 +101,7 @@ function CryptoTable() {
                             <TableCell onClick={() => handleSort('price')}>
                                 <HeaderWithTooltip
                                     title="Price"
-                                    tooltip="Price is the cost of a single coin or token for a cryptocurrency. It is influenced by supply & demand, availibility, and many other factors."
+                                    tooltip="Price is the cost of a single coin or token for a cryptocurrency. It is influenced by supply & demand, availability, and many other factors."
                                     sortable
                                     sortActive={sortConfig.key === 'price'}
                                     sortDirection={sortConfig.direction}


### PR DESCRIPTION
## Summary
- fix misspelled word in crypto table price tooltip

## Testing
- `npm install` *(fails: network access blocked)*
- `npm test` *(fails: react-scripts not found due to failed install)*

------
https://chatgpt.com/codex/tasks/task_e_6872fe7a2a0883298f93251de81d7901